### PR TITLE
[gitlab_runner] Add `gpus` option for docker-type Gitlab runners

### DIFF
--- a/ansible/roles/gitlab_runner/templates/etc/gitlab-runner/config.toml.j2
+++ b/ansible/roles/gitlab_runner/templates/etc/gitlab-runner/config.toml.j2
@@ -153,6 +153,9 @@ metrics_server = "{{ gitlab_runner__metrics_server }}"
 {%       if runner.docker_cpus is defined %}
     cpus = "{{ runner.docker_cpus }}"
 {%       endif %}
+{%       if runner.docker_gpus is defined %}
+    gpus = "{{ runner.docker_gpus }}"
+{%       endif %}
 {%       if runner.docker_disable_entrypoint_overwrite is defined %}
     disable_entrypoint_overwrite = {{ runner.docker_disable_entrypoint_overwrite | bool | lower }}
 {%       endif %}


### PR DESCRIPTION
Allow setting of `gpus` for docker runners using `docker_gpus`.